### PR TITLE
Make the prison matching algorithm more flexible

### DIFF
--- a/lib/wcn_scraper/prison.rb
+++ b/lib/wcn_scraper/prison.rb
@@ -3,10 +3,19 @@ module WcnScraper
     class PrisonNotFoundError < StandardError
     end
 
+    class NoPrisonsFoundError < StandardError
+    end
+
     def self.find(prison_name)
       prison = PRISONS.find { |p| p[:name] == prison_name }
       raise self::PrisonNotFoundError, "#{prison_name} not found" if prison.nil?
       Prison.new(prison)
+    end
+
+    def self.find_in_string(string)
+      matches = PRISONS.select { |p| string.include? p[:name] }
+      raise self::NoPrisonsFoundError if matches.empty?
+      matches.map { |p| Prison.new(p) }
     end
 
     attr_reader :name, :lat, :lng
@@ -15,6 +24,14 @@ module WcnScraper
       @name = params[:name]
       @lat = params[:lat]
       @lng = params[:lng]
+    end
+
+    def attrs
+      {
+        name: @name,
+        lat: @lat,
+        lng: @lng
+      }
     end
   end
 end

--- a/lib/wcn_scraper/vacancy.rb
+++ b/lib/wcn_scraper/vacancy.rb
@@ -23,11 +23,7 @@ module WcnScraper
     end
 
     def prisons
-      @prisons ||= begin
-        prisons = title.split('-').last
-        prisons = prisons.gsub(/ and /i, ' & ').split(/[,&]/).map(&:strip)
-        prisons.map { |p| Prison.find(p) }
-      end
+      @prisons ||= Prison.find_in_string(title)
     end
 
     def closing_date

--- a/spec/wcn_scraper/prison_spec.rb
+++ b/spec/wcn_scraper/prison_spec.rb
@@ -1,6 +1,17 @@
 require_relative '../spec_helper'
 
 describe WcnScraper::Prison do
+  before do
+    stub_const('PRISONS',
+      [
+        { name: 'HMP Berwyn', lat: 53.036418, lng: -2.9292142 },
+        { name: 'HMP Brixton', lat: 51.4516617, lng: -0.1250917 },
+        { name: 'HMP Chelmsford', lat: 51.7361324, lng: 0.4860732999999999 },
+        { name: 'HMP Coldingley', lat: 51.3217467, lng: -0.6432669 },
+        { name: 'HMP Dartmoor', lat: 50.5495271, lng: -3.9963275 }
+      ])
+  end
+
   describe '#new' do
     subject(:prison) do
       described_class.new(
@@ -23,18 +34,26 @@ describe WcnScraper::Prison do
     end
   end
 
-  describe '.find' do
-    before do
-      stub_const('PRISONS', [
-          { name: 'HMP Berwyn', lat: 53.036418, lng: -2.9292142 },
-          { name: 'HMP Brixton', lat: 51.4516617, lng: -0.1250917 },
-          { name: 'HMP Chelmsford', lat: 51.7361324, lng: 0.4860732999999999 },
-          { name: 'HMP Coldingley', lat: 51.3217467, lng: -0.6432669 },
-          { name: 'HMP Dartmoor', lat: 50.5495271, lng: -3.9963275 }
-      ])
+  describe '#attrs' do
+    subject(:prison) do
+      described_class.new(
+        name: 'HMP Brixton',
+        lat: 51.4516617,
+        lng: -0.1250917
+      )
     end
 
-    context 'happy path' do
+    it 'returns all attributes of the Prison' do
+      expect(prison.attrs).to eq(
+        name: 'HMP Brixton',
+        lat: 51.4516617,
+        lng: -0.1250917
+      )
+    end
+  end
+
+  describe '.find' do
+    context 'given a valid prison name' do
       subject(:prison) { described_class.find('HMP Brixton') }
 
       it 'returns a Prison instance' do
@@ -45,15 +64,68 @@ describe WcnScraper::Prison do
         expect(prison).not_to eq(described_class.find('HMP Brixton'))
       end
 
-      specify { expect(prison.name).to eq('HMP Brixton') }
-      specify { expect(prison.lat).to eq(51.4516617) }
-      specify { expect(prison.lng).to eq(-0.1250917) }
+      it 'returns the correct prison' do
+        expect(prison.attrs).to eq(
+          name: 'HMP Brixton',
+          lat: 51.4516617,
+          lng: -0.1250917
+        )
+      end
     end
 
-    context 'non-existent prison' do
+    context 'given a non-existent prison name' do
       subject(:prison) { described_class.find('HMP Azkaban') }
 
-      specify { expect { prison }.to raise_error(WcnScraper::Prison::PrisonNotFoundError, 'HMP Azkaban not found') }
+      specify do
+        expect { prison }.to raise_error(WcnScraper::Prison::PrisonNotFoundError, 'HMP Azkaban not found')
+      end
+    end
+  end
+
+  describe '.find_in_string' do
+    context 'given a string containing one prison' do
+      subject(:prisons) { described_class.find_in_string('201706: Prison Officer - HMP Brixton') }
+
+      it 'returns an array of Prison instances' do
+        expect(prisons).to all(be_a(described_class))
+      end
+
+      it 'returns one result' do
+        expect(prisons.count).to eq(1)
+      end
+
+      it 'returns the correct prison' do
+        expected_prison = { name: 'HMP Brixton', lat: 51.4516617, lng: -0.1250917 }
+        expect(prisons.first.attrs).to eq(expected_prison)
+      end
+    end
+
+    context 'given a string containing two prisons' do
+      subject(:prisons) { described_class.find_in_string('201706: Prison Officer - HMP Chelmsford & HMP Dartmoor') }
+
+      it 'returns an array of Prison instances' do
+        expect(prisons).to all(be_a(described_class))
+      end
+
+      it 'returns two results' do
+        expect(prisons.count).to eq(2)
+      end
+
+      it 'returns the correct prisons' do
+        expected_prisons = [
+          { name: 'HMP Chelmsford', lat: 51.7361324, lng: 0.4860732999999999 },
+          { name: 'HMP Dartmoor', lat: 50.5495271, lng: -3.9963275 }
+        ]
+        expect(prisons.map(&:attrs)).to match_array(expected_prisons)
+      end
+    end
+
+    context 'given a string containing no prisons' do
+      subject(:prisons) { described_class.find_in_string('201706: Prison Officer - Something Badly Formatted') }
+
+      specify do
+        expect { prisons }.to raise_error(WcnScraper::Prison::NoPrisonsFoundError)
+      end
     end
   end
 end


### PR DESCRIPTION
This improves the matching algorithm used to find prisons from vacancy titles. Prisons are now matched using substrings – in other words, it will simply search the vacancy title for known prison names.

This is an improvement over the old method since it doesn't make any assumptions about the structure of the vacancy title.