### PR TITLE
Add town name and role type to data output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Fetching jobs from WCN
 
-This has been deprecated in favour of [ministryofjustice/hmpps-job-feed-parser](https://github.com/ministryofjustice/hmpps-job-feed-parser).
-
 ## RSS
 
 WCN publish an RSS feed of all jobs, at;
@@ -45,17 +43,49 @@ The corresponding HTML page is here;
 https://justicejobs.tal.net/vx/lang-en-GB/mobile-0/appcentre-1/brand-2/xf-a5f8e63220f3/candidate/jobboard/vacancy/3/adv/?ftq=prison+officer
 ```
 
-# TODO
+## Output schema
 
-* Turn `salary` into a number (or a range)
+Structured job data will be output in the following format:
 
-Examples of real `salary` values;
-
+```json
+{
+  "title": "201710: Prison Officer - HMP/YOI Isle of Wight",
+  "role": "Prison Officer",
+  "salary": "£22,396",
+  "closing_date": "31/10/2017",
+  "prison_name": "HMP/YOI Isle of Wight",
+  "prison_location": {
+    "lat": 50.713196,
+    "lng": -1.3076464,
+    "town": "Newport"
+  },
+  "url": "https://justicejobs.tal.net/vx/mobile-0/appcentre-1/brand-13/candidate/so/pm/1/pl/3/opp/13634-201710-Prison-Officer-HMP-YOI-Isle-of-Wight/en-GB"
+}
 ```
-For 41 hours a week, £32,843, For 39 hours a week, £31,453
-£26,456
-£28,456 - £29,403
-£29, 453
-```
 
-* Turn `closing_date` into a date
+| Field name | Type | Description |
+| ---------- | ---- | ----------- |
+| `title`    | String | The vacancy title. |
+| `role`     | String | The job role of this vacancy. This will always be 'Prison Officer', since that's the only role this script currently retrieves data for. |
+| `salary`   | String | The vacancy salary. This is untouched and passed through as a string. Do not attempt to treat this as a number, as it's unknown whether this always follows a predictable format. |
+| `closing_date` | Date (DD/MM/YYYY) | The vacancy closing date in DD/MM/YYYY format. |
+| `prison_name` | String | Name of the prison in which this vacancy exists. |
+| `prison_location` | Object | Object with sub-fields: |
+| `prison_location.lat` | Float | Latitude of the prison. |
+| `prison_location.lng` | Float | Longitude of the prison. |
+| `prison_location.town` | String | Name of the town in which the prison exists. |
+| `url` | String | URL of the vacancy details page. |
+
+### Vacancies in multiple prisons
+
+Vacancies in multiple prisons (e.g. cluster vacancies), one entry will be output for each prison.
+
+This will result in duplicate vacancy data being surfaced – once for each prison.
+
+If required, vacancies can be re-grouped by matching them against the URL. This will be unique per vacancy.
+
+### JSON file in S3
+
+This structured vacancy data will be output to a JSON file in an S3 bucket. This functionality has yet to be developed.
+
+This JSON file will contain an array of objects following the aforementioned output schema.

--- a/data/prisons.yaml
+++ b/data/prisons.yaml
@@ -1,174 +1,232 @@
 - :name: HMP Berwyn
+  :town: Unknown
   :lat: 53.036418
   :lng: -2.9292142
 - :name: HMP Brixton
+  :town: Unknown
   :lat: 51.4516617
   :lng: -0.1250917
 - :name: HMP Bure
+  :town: Unknown
   :lat: 52.759454
   :lng: 1.3458199
 - :name: HMP Cardiff
+  :town: Unknown
   :lat: 51.4810689
   :lng: -3.1683326
 - :name: HMP Channings Wood
+  :town: Unknown
   :lat: 50.5104924
   :lng: -3.6518204
 - :name: HMP Chelmsford
+  :town: Unknown
   :lat: 51.7361324
   :lng: 0.4860732999999999
 - :name: HMP Coldingley
+  :town: Unknown
   :lat: 51.3217467
   :lng: -0.6432669
 - :name: HMP Dartmoor
+  :town: Unknown
   :lat: 50.5495271
   :lng: -3.9963275
 - :name: HMP Eastwood Park
+  :town: Unknown
   :lat: 51.63504709999999
   :lng: -2.468383
 - :name: HMP Erlestoke
+  :town: Unknown
   :lat: 51.2833485
   :lng: -2.0430271
 - :name: HMP Featherstone
+  :town: Unknown
   :lat: 52.6473483
   :lng: -2.1098351
 - :name: HMP Grendon
+  :town: Unknown
   :lat: 51.8931365
   :lng: -1.0072932
 - :name: HMP Guys Marsh
+  :town: Unknown
   :lat: 50.9847775
   :lng: -2.2215698
 - :name: HMP Haverigg
+  :town: Unknown
   :lat: 54.2022592
   :lng: -3.3125602
 - :name: HMP Hewell
+  :town: Unknown
   :lat: 52.3246695
   :lng: -1.9870964
 - :name: HMP High Down
+  :town: Unknown
   :lat: 51.3357233
   :lng: -0.1890383
 - :name: HMP Highpoint
+  :town: Unknown
   :lat: 52.136974
   :lng: 0.510659
 - :name: HMP Hollesley Bay
+  :town: Unknown
   :lat: 52.051042
   :lng: 1.451328
 - :name: HMP Humber
+  :town: Unknown
   :lat: 53.7693399
   :lng: -0.6410579
 - :name: HMP Huntercombe
+  :town: Unknown
   :lat: 51.5874
   :lng: -1.0183
 - :name: HMP Kirkham
+  :town: Unknown
   :lat: 53.774924
   :lng: -2.8731828
 - :name: HMP Leicester
+  :town: Unknown
   :lat: 52.6274509
   :lng: -1.131901
 - :name: HMP Leyhill
+  :town: Unknown
   :lat: 51.62803419999999
   :lng: -2.4367766
 - :name: HMP Lincoln
+  :town: Unknown
   :lat: 53.234813
   :lng: -0.51721
 - :name: IRC Morton Hall
+  :town: Unknown
   :lat: 53.167904
   :lng: -0.689086
 - :name: HMP Littlehey
+  :town: Unknown
   :lat: 52.2805913
   :lng: -0.3122374
 - :name: HMP Long Lartin
+  :town: Unknown
   :lat: 52.108459
   :lng: -1.8540072
 - :name: HMP Low Newton
+  :town: Unknown
   :lat: 54.8064867
   :lng: -1.549427
 - :name: HMP Maidstone
+  :town: Unknown
   :lat: 51.2793606
   :lng: 0.5237286
 - :name: HMP Norwich
+  :town: Unknown
   :lat: 52.6369762
   :lng: 1.3179051
 - :name: HMP Onley
+  :town: Unknown
   :lat: 52.3269943
   :lng: -1.2465741
 - :name: HMP Ranby
+  :town: Unknown
   :lat: 53.3200826
   :lng: -0.9961172
 - :name: HMP Stocken
+  :town: Unknown
   :lat: 52.7469327
   :lng: -0.5821626999999999
 - :name: HMP Swaleside
+  :town: Unknown
   :lat: 51.3929227
   :lng: 0.8536864000000001
 - :name: HMP The Mount
+  :town: Unknown
   :lat: 51.72473859999999
   :lng: -0.5410677
 - :name: HMP Usk/Prescoed
+  :town: Unknown
   :lat: 51.6856926
   :lng: -2.9414967
 - :name: HMP Wandsworth
+  :town: Unknown
   :lat: 51.4500051
   :lng: -0.1775711
 - :name: HMP Wayland
+  :town: Unknown
   :lat: 52.5538889
   :lng: 0.8580555999999999
 - :name: HMP Whatton
+  :town: Unknown
   :lat: 52.9472902
   :lng: -0.9116372
 - :name: HMP Whitemoor
+  :town: Unknown
   :lat: 52.57534589999999
   :lng: 0.0811047
 - :name: HMP Winchester
+  :town: Unknown
   :lat: 51.0625986
   :lng: -1.3279811
 - :name: HMP Woodhill
+  :town: Unknown
   :lat: 52.0143898
   :lng: -0.8083142
 - :name: HMP/YOI Bedford
+  :town: Unknown
   :lat: 52.1389661
   :lng: -0.4696008999999999
 - :name: HMP/YOI Downview
+  :town: Unknown
   :lat: 51.3384631
   :lng: -0.1880442
 - :name: HMP/YOI Drake Hall
+  :town: Unknown
   :lat: 52.87726
   :lng: -2.2425361
 - :name: HMP/YOI Foston Hall
+  :town: Unknown
   :lat: 52.8822614
   :lng: -1.7253463
 - :name: HMP/YOI Isis
+  :town: Unknown
   :lat: 51.4976997
   :lng: 0.09784160000000001
 - :name: HMP/YOI Isle of Wight
+  :town: Unknown
   :lat: 50.713196
   :lng: -1.3076464
 - :name: HMP/YOI Lewes
+  :town: Unknown
   :lat: 50.8722285
   :lng: -0.005117099999999999
 - :name: HMP/YOI Send
+  :town: Unknown
   :lat: 51.2716941
   :lng: -0.4908906
 - :name: HMP/YOI Wormwood Scrubs
+  :town: Unknown
   :lat: 51.5169637
   :lng: -0.2403418
 - :name: HMYOI Aylesbury
+  :town: Unknown
   :lat: 51.8225809
   :lng: -0.8016525999999999
 - :name: HMYOI Cookham Wood
+  :town: Unknown
   :lat: 51.3663986
   :lng: 0.4942465
 - :name: HMYOI Deerbolt
+  :town: Unknown
   :lat: 54.5432115
   :lng: -1.9367631
 - :name: HMYOI Feltham
+  :town: Unknown
   :lat: 51.4415566
   :lng: -0.4340565
 - :name: HMYOI Portland & IRC Verne
+  :town: Unknown
   :lat: 50.5497794
   :lng: -2.4219912
 - :name: HMYOI Stoke Heath
+  :town: Unknown
   :lat: 52.8688371
   :lng: -2.5218096
 - :name: HMYOI Swinfen Hall
+  :town: Unknown
   :lat: 52.6525736
   :lng: -1.8066018

--- a/lib/vacancy_formatter.rb
+++ b/lib/vacancy_formatter.rb
@@ -11,10 +11,11 @@ class VacancyFormatter
     vacancy.prisons.map do |prison|
       {
         title: vacancy.title,
+        role: vacancy.role,
         salary: vacancy.salary,
         closing_date: vacancy.closing_date.strftime('%d/%m/%Y'),
         prison_name: prison.name,
-        prison_location: { lat: prison.lat, lng: prison.lng },
+        prison_location: { town: prison.town, lat: prison.lat, lng: prison.lng },
         url: vacancy.url
       }
     end

--- a/lib/wcn_scraper/prison.rb
+++ b/lib/wcn_scraper/prison.rb
@@ -18,19 +18,21 @@ module WcnScraper
       matches.map { |p| Prison.new(p) }
     end
 
-    attr_reader :name, :lat, :lng
+    attr_reader :name, :lat, :lng, :town
 
     def initialize(params)
       @name = params[:name]
       @lat = params[:lat]
       @lng = params[:lng]
+      @town = params[:town]
     end
 
     def attrs
       {
         name: @name,
         lat: @lat,
-        lng: @lng
+        lng: @lng,
+        town: @town
       }
     end
   end

--- a/lib/wcn_scraper/vacancy.rb
+++ b/lib/wcn_scraper/vacancy.rb
@@ -7,7 +7,7 @@ module WcnScraper
     def initialize(url, html)
       @url = url
       @html = html
-      @role = 'prison-officer' # hardcoded until other roles are introduced
+      @role = 'Prison Officer' # hardcoded until other roles are introduced
     end
 
     def id

--- a/spec/vacancy_formatter_spec.rb
+++ b/spec/vacancy_formatter_spec.rb
@@ -4,10 +4,10 @@ describe VacancyFormatter do
   before do
     stub_const('PRISONS',
       [
-        { name: 'HMP/YOI Downview', lat: 51.338463, lng: -0.188044 },
-        { name: 'HMP/YOI Isle of Wight', lat: 50.713196, lng: -1.3076464 },
-        { name: 'HMP Littlehey', lat: 52.2805913, lng: -0.3122374 },
-        { name: 'HMP Stocken', lat: 52.7469327, lng: -0.5821626999999999 }
+        { name: 'HMP/YOI Downview', town: 'Sutton', lat: 51.338463, lng: -0.188044 },
+        { name: 'HMP/YOI Isle of Wight', town: 'Newport', lat: 50.713196, lng: -1.3076464 },
+        { name: 'HMP Littlehey', town: 'Huntingdon', lat: 52.2805913, lng: -0.3122374 },
+        { name: 'HMP Stocken', town: 'Oakham', lat: 52.7469327, lng: -0.5821626999999999 }
       ])
   end
 
@@ -60,34 +60,38 @@ describe VacancyFormatter do
         [
           {
             title: '201706: Prison Officer - HMP/YOI Downview',
+            role: 'Prison Officer',
             salary: '£31,453',
             closing_date: '07/07/2017',
             prison_name: 'HMP/YOI Downview',
-            prison_location: { lat: 51.338463, lng: -0.188044 },
+            prison_location: { town: 'Sutton', lat: 51.338463, lng: -0.188044 },
             url: 'https://justicejobs.tal.net/vx/mobile-0/appcentre-1/brand-13/candidate/so/pm/1/pl/3/opp/9908-201706-Prison-Officer-HMP-YOI-Downview/en-GB'
           },
           {
             title: '201711: Prison Officer - HMP Littlehey & HMP Stocken',
+            role: 'Prison Officer',
             salary: '£22,396',
             closing_date: '30/11/2017',
             prison_name: 'HMP Littlehey',
-            prison_location: { lat: 52.2805913, lng: -0.3122374 },
+            prison_location: { town: 'Huntingdon', lat: 52.2805913, lng: -0.3122374 },
             url: 'https://justicejobs.tal.net/vx/mobile-0/appcentre-1/brand-13/candidate/so/pm/1/pl/3/opp/14225-201711-Prison-Officer-HMP-Littlehey-HMP-Stocken/en-GB'
           },
           {
             title: '201711: Prison Officer - HMP Littlehey & HMP Stocken',
+            role: 'Prison Officer',
             salary: '£22,396',
             closing_date: '30/11/2017',
             prison_name: 'HMP Stocken',
-            prison_location: { lat: 52.7469327, lng: -0.5821626999999999 },
+            prison_location: { town: 'Oakham', lat: 52.7469327, lng: -0.5821626999999999 },
             url: 'https://justicejobs.tal.net/vx/mobile-0/appcentre-1/brand-13/candidate/so/pm/1/pl/3/opp/14225-201711-Prison-Officer-HMP-Littlehey-HMP-Stocken/en-GB'
           },
           {
             title: '201710: Prison Officer - HMP/YOI Isle of Wight',
+            role: 'Prison Officer',
             salary: '£22,396',
             closing_date: '30/11/2017',
             prison_name: 'HMP/YOI Isle of Wight',
-            prison_location: { lat: 50.713196, lng: -1.3076464 },
+            prison_location: { town: 'Newport', lat: 50.713196, lng: -1.3076464 },
             url: 'https://justicejobs.tal.net/vx/mobile-0/appcentre-1/brand-13/candidate/so/pm/1/pl/3/opp/13634-201710-Prison-Officer-HMP-YOI-Isle-of-Wight/en-GB'
           }
         ]
@@ -126,10 +130,11 @@ describe VacancyFormatter do
         [
           {
             title: '201706: Prison Officer - HMP/YOI Downview',
+            role: 'Prison Officer',
             salary: '£31,453',
             closing_date: '07/07/2017',
             prison_name: 'HMP/YOI Downview',
-            prison_location: { lat: 51.338463, lng: -0.188044 },
+            prison_location: { town: 'Sutton', lat: 51.338463, lng: -0.188044 },
             url: 'https://justicejobs.tal.net/vx/mobile-0/appcentre-1/brand-13/candidate/so/pm/1/pl/3/opp/9908-201706-Prison-Officer-HMP-YOI-Downview/en-GB'
           }
         ]
@@ -166,18 +171,20 @@ describe VacancyFormatter do
         [
           {
             title: '201711: Prison Officer - HMP Littlehey & HMP Stocken',
+            role: 'Prison Officer',
             salary: '£22,396',
             closing_date: '30/11/2017',
             prison_name: 'HMP Littlehey',
-            prison_location: { lat: 52.2805913, lng: -0.3122374 },
+            prison_location: { town: 'Huntingdon', lat: 52.2805913, lng: -0.3122374 },
             url: 'https://justicejobs.tal.net/vx/mobile-0/appcentre-1/brand-13/candidate/so/pm/1/pl/3/opp/14225-201711-Prison-Officer-HMP-Littlehey-HMP-Stocken/en-GB'
           },
           {
             title: '201711: Prison Officer - HMP Littlehey & HMP Stocken',
+            role: 'Prison Officer',
             salary: '£22,396',
             closing_date: '30/11/2017',
             prison_name: 'HMP Stocken',
-            prison_location: { lat: 52.7469327, lng: -0.5821626999999999 },
+            prison_location: { town: 'Oakham', lat: 52.7469327, lng: -0.5821626999999999 },
             url: 'https://justicejobs.tal.net/vx/mobile-0/appcentre-1/brand-13/candidate/so/pm/1/pl/3/opp/14225-201711-Prison-Officer-HMP-Littlehey-HMP-Stocken/en-GB'
           }
         ]

--- a/spec/wcn_scraper/prison_spec.rb
+++ b/spec/wcn_scraper/prison_spec.rb
@@ -4,11 +4,11 @@ describe WcnScraper::Prison do
   before do
     stub_const('PRISONS',
       [
-        { name: 'HMP Berwyn', lat: 53.036418, lng: -2.9292142 },
-        { name: 'HMP Brixton', lat: 51.4516617, lng: -0.1250917 },
-        { name: 'HMP Chelmsford', lat: 51.7361324, lng: 0.4860732999999999 },
-        { name: 'HMP Coldingley', lat: 51.3217467, lng: -0.6432669 },
-        { name: 'HMP Dartmoor', lat: 50.5495271, lng: -3.9963275 }
+        { name: 'HMP Berwyn', town: 'Wrexham', lat: 53.036418, lng: -2.9292142 },
+        { name: 'HMP Brixton', town: 'London', lat: 51.4516617, lng: -0.1250917 },
+        { name: 'HMP Chelmsford', town: 'Chelmsford', lat: 51.7361324, lng: 0.4860732999999999 },
+        { name: 'HMP Coldingley', town: 'Woking', lat: 51.3217467, lng: -0.6432669 },
+        { name: 'HMP Dartmoor', town: 'Yelverton', lat: 50.5495271, lng: -3.9963275 }
       ])
   end
 
@@ -17,7 +17,8 @@ describe WcnScraper::Prison do
       described_class.new(
         name: 'HMP Brixton',
         lat: 51.4516617,
-        lng: -0.1250917
+        lng: -0.1250917,
+        town: 'London'
       )
     end
 
@@ -32,6 +33,10 @@ describe WcnScraper::Prison do
     it 'sets the longitude' do
       expect(prison.lng).to eq(-0.1250917)
     end
+
+    it 'sets the town' do
+      expect(prison.town).to eq('London')
+    end
   end
 
   describe '#attrs' do
@@ -39,7 +44,8 @@ describe WcnScraper::Prison do
       described_class.new(
         name: 'HMP Brixton',
         lat: 51.4516617,
-        lng: -0.1250917
+        lng: -0.1250917,
+        town: 'London'
       )
     end
 
@@ -47,7 +53,8 @@ describe WcnScraper::Prison do
       expect(prison.attrs).to eq(
         name: 'HMP Brixton',
         lat: 51.4516617,
-        lng: -0.1250917
+        lng: -0.1250917,
+        town: 'London'
       )
     end
   end
@@ -68,7 +75,8 @@ describe WcnScraper::Prison do
         expect(prison.attrs).to eq(
           name: 'HMP Brixton',
           lat: 51.4516617,
-          lng: -0.1250917
+          lng: -0.1250917,
+          town: 'London'
         )
       end
     end
@@ -95,7 +103,7 @@ describe WcnScraper::Prison do
       end
 
       it 'returns the correct prison' do
-        expected_prison = { name: 'HMP Brixton', lat: 51.4516617, lng: -0.1250917 }
+        expected_prison = { name: 'HMP Brixton', town: 'London', lat: 51.4516617, lng: -0.1250917 }
         expect(prisons.first.attrs).to eq(expected_prison)
       end
     end
@@ -113,8 +121,8 @@ describe WcnScraper::Prison do
 
       it 'returns the correct prisons' do
         expected_prisons = [
-          { name: 'HMP Chelmsford', lat: 51.7361324, lng: 0.4860732999999999 },
-          { name: 'HMP Dartmoor', lat: 50.5495271, lng: -3.9963275 }
+          { name: 'HMP Chelmsford', town: 'Chelmsford', lat: 51.7361324, lng: 0.4860732999999999 },
+          { name: 'HMP Dartmoor', town: 'Yelverton', lat: 50.5495271, lng: -3.9963275 }
         ]
         expect(prisons.map(&:attrs)).to match_array(expected_prisons)
       end

--- a/spec/wcn_scraper/vacancy_spec.rb
+++ b/spec/wcn_scraper/vacancy_spec.rb
@@ -31,7 +31,7 @@ describe WcnScraper::Vacancy do
       specify { expect(vacancy.id).to eq('9908') }
       specify { expect(vacancy.url).to eq(url) }
       specify { expect(vacancy.title).to eq('201706: Prison Officer - HMP/YOI Downview') }
-      specify { expect(vacancy.role).to eq('prison-officer') }
+      specify { expect(vacancy.role).to eq('Prison Officer') }
       specify { expect(vacancy.salary).to eq('£31,453') }
       specify { expect(vacancy.prisons.count).to eq(1) }
       specify { expect(vacancy.prisons).to all(be_a(WcnScraper::Prison)) }
@@ -59,7 +59,7 @@ describe WcnScraper::Vacancy do
       specify { expect(vacancy.id).to eq('14225') }
       specify { expect(vacancy.url).to eq(url) }
       specify { expect(vacancy.title).to eq('201711: Prison Officer - HMP Littlehey & HMP Stocken') }
-      specify { expect(vacancy.role).to eq('prison-officer') }
+      specify { expect(vacancy.role).to eq('Prison Officer') }
       specify { expect(vacancy.salary).to eq('£22,396') }
       specify { expect(vacancy.prisons.count).to eq(2) }
       specify { expect(vacancy.prisons).to all(be_a(WcnScraper::Prison)) }


### PR DESCRIPTION
I've added the prison town name and vacancy role type to the data output. This has also required changes to the prison data file `data/prisons.yaml` – although without re-geocoding the list of prisons, I don't have the town name available so have left them all as 'Unknown' for now.

A section has been added to the README file to document the output data schema.