### PR TITLE
Renamed IRC The Verne to HMP The Verne

### DIFF
--- a/data/prisons.txt
+++ b/data/prisons.txt
@@ -125,8 +125,8 @@ HMYOI Feltham
 HMYOI Werrington
 HMYOI Wetherby
 IRC Morton Hall
-IRC The Verne
-IRC Verne
+HMP The Verne
+The Verne
 Medway STC
 Oakhill STC
 Rainsbrook STC

--- a/data/prisons.yaml
+++ b/data/prisons.yaml
@@ -3,7 +3,7 @@
   :lat: 53.1679042
   :lng: -0.6890860999999999
   :type: Prison
-- :name: IRC The Verne
+- :name: HMP The Verne
   :town: Moffat
   :lat: 50.5615548
   :lng: -2.4357944
@@ -1478,7 +1478,7 @@
   :lat: 53.9356199
   :lng: -1.3693436
   :type: Youth Custody
-- :name: IRC Verne
+- :name: The Verne
   :town: Moffat
   :lat: 50.5615548
   :lng: -2.4357944

--- a/spec/fixtures/feed.xml
+++ b/spec/fixtures/feed.xml
@@ -2987,11 +2987,11 @@ Closing Date:31 Oct 2017 23:55 GMT<br/>
   <entry xml:base="https://justicejobs.tal.net/vx/mobile-0/appcentre-1/brand-13/candidate/so/pm/1/pl/3/opp/9926-201706-Prison-Officer-HMYOI-Portland-IRC-Verne/en-GB">
     <id>https://justicejobs.tal.net/vx/mobile-0/appcentre-1/brand-13/candidate/so/pm/1/pl/3/opp/9926-201706-Prison-Officer-HMYOI-Portland-IRC-Verne/en-GB</id>
     <link rel="alternate" href="https://justicejobs.tal.net/vx/mobile-0/appcentre-1/brand-13/candidate/so/pm/1/pl/3/opp/9926-201706-Prison-Officer-HMYOI-Portland-IRC-Verne/en-GB" type="text/html"/>
-    <title>201706: Prison Officer -  HMYOI Portland &amp; IRC Verne</title>
+    <title>201706: Prison Officer -  HMYOI Portland &amp; HMP The Verne</title>
     <updated>2017-05-31T23:00:00Z</updated>
     <published>2017-05-31T23:00:00Z</published>
     <content type="xhtml">
-      <div xmlns="http://www.w3.org/1999/xhtml">Vacancy Title:201706: Prison Officer -  HMYOI Portland &amp; IRC Verne<br/>
+      <div xmlns="http://www.w3.org/1999/xhtml">Vacancy Title:201706: Prison Officer -  HMYOI Portland &amp; HMP The Verne<br/>
 Vacancy Id:9926<br/>
 Role Type:Operational Delivery,Prison Officer<br/>
 Salary:£22,396<br/>


### PR DESCRIPTION
Found mentions of **IRC The Verne** and replaced with **HMP The Verne**
Found mentions of **IRC Verne** and replaced with **The Verne**